### PR TITLE
Add SQLite DB service

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,9 @@ import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
+import { useEffect } from 'react';
+
+import { initDatabase } from '@/services/database';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 
@@ -11,6 +14,10 @@ export default function RootLayout() {
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
+
+  useEffect(() => {
+    initDatabase().catch(console.warn);
+  }, []);
 
   if (!loaded) {
     // Async font loading only occurs in development.

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
         "react-native-web": "~0.20.0",
-        "react-native-webview": "13.13.5"
+        "react-native-webview": "13.13.5",
+        "react-native-sqlite-storage": "^6.2.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -10367,6 +10368,16 @@
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-sqlite-storage": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-sqlite-storage/-/react-native-sqlite-storage-6.2.1.tgz",
+      "integrity": "sha512-5EdGN8y7kwh28ykVfoCEN0z7LxyzKDn5XxhxL7sRKqzZo4PMBVXgS5aXoaZySUdkGFUTkOcJCIZy9FHn5Vf3og==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "react-native-sqlite-storage": "^6.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/services/database.ts
+++ b/services/database.ts
@@ -1,0 +1,81 @@
+import SQLite, { SQLiteDatabase, ResultSet } from 'react-native-sqlite-storage';
+
+SQLite.enablePromise(true);
+
+const DB_NAME = 'budget.db';
+
+async function getDb(): Promise<SQLiteDatabase> {
+  return SQLite.openDatabase({ name: DB_NAME, location: 'default' });
+}
+
+export async function initDatabase() {
+  const db = await getDb();
+  await db.executeSql(
+    `CREATE TABLE IF NOT EXISTS income (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      amount REAL,
+      description TEXT,
+      date TEXT
+    );`
+  );
+  await db.executeSql(
+    `CREATE TABLE IF NOT EXISTS expenses (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      amount REAL,
+      description TEXT,
+      date TEXT
+    );`
+  );
+  await db.executeSql(
+    `CREATE TABLE IF NOT EXISTS envelopes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT,
+      budget REAL
+    );`
+  );
+  await db.executeSql(
+    `CREATE TABLE IF NOT EXISTS debts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      amount REAL,
+      description TEXT,
+      date TEXT
+    );`
+  );
+}
+
+export async function executeSql(sql: string, params: any[] = []): Promise<ResultSet> {
+  const db = await getDb();
+  const [result] = await db.executeSql(sql, params);
+  return result;
+}
+
+export async function getAll<T = any>(table: string): Promise<T[]> {
+  const result = await executeSql(`SELECT * FROM ${table}`);
+  const items: T[] = [];
+  for (let i = 0; i < result.rows.length; i++) {
+    items.push(result.rows.item(i));
+  }
+  return items;
+}
+
+export async function insert(table: string, fields: Record<string, any>) {
+  const keys = Object.keys(fields);
+  const placeholders = keys.map(() => '?').join(', ');
+  const values = Object.values(fields);
+  await executeSql(
+    `INSERT INTO ${table} (${keys.join(', ')}) VALUES (${placeholders})`,
+    values
+  );
+}
+
+export async function update(table: string, fields: Record<string, any>, id: number) {
+  const set = Object.keys(fields)
+    .map((key) => `${key} = ?`)
+    .join(', ');
+  const values = [...Object.values(fields), id];
+  await executeSql(`UPDATE ${table} SET ${set} WHERE id = ?`, values);
+}
+
+export async function remove(table: string, id: number) {
+  await executeSql(`DELETE FROM ${table} WHERE id = ?`, [id]);
+}


### PR DESCRIPTION
## Summary
- add `react-native-sqlite-storage` dependency
- create a reusable SQLite service with CRUD helpers
- init database when the root layout mounts

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68562a3c100c8325910a526913171cd4