### PR TITLE
Add income events screen

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,6 +40,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="income"
+        options={{
+          title: 'Income',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="dollarsign.circle" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/income.tsx
+++ b/app/(tabs)/income.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useState } from 'react';
+import { View, TextInput, Button, Switch, StyleSheet, FlatList } from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { getAll, insert } from '@/services/db/DatabaseService';
+
+type Income = {
+  id: string;
+  name: string;
+  amount: number;
+  date: string;
+  recurring: number;
+};
+
+export default function IncomeScreen() {
+  const [incomes, setIncomes] = useState<Income[]>([]);
+  const [name, setName] = useState('');
+  const [amount, setAmount] = useState('');
+  const [date, setDate] = useState('');
+  const [recurring, setRecurring] = useState(false);
+
+  useEffect(() => {
+    loadIncomes();
+  }, []);
+
+  const loadIncomes = async () => {
+    try {
+      const data = (await getAll('income_events')) as Income[];
+      setIncomes(data);
+    } catch (e) {
+      console.warn(e);
+    }
+  };
+
+  const addIncome = async () => {
+    if (!name || !amount || !date) return;
+    try {
+      await insert('income_events', {
+        id: Date.now().toString(),
+        name,
+        amount: parseFloat(amount),
+        date,
+        recurring: recurring ? 1 : 0,
+      });
+      setName('');
+      setAmount('');
+      setDate('');
+      setRecurring(false);
+      loadIncomes();
+    } catch (e) {
+      console.warn(e);
+    }
+  };
+
+  const monthlyTotal = () => {
+    const now = new Date();
+    return incomes
+      .filter((i) => {
+        const d = new Date(i.date);
+        return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear();
+      })
+      .reduce((sum, i) => sum + i.amount, 0);
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText type="title" style={styles.header}>Income</ThemedText>
+      <ThemedText style={styles.total}>Total this month: ${monthlyTotal().toFixed(2)}</ThemedText>
+      <View style={styles.form}>
+        <TextInput
+          placeholder="Name"
+          style={styles.input}
+          value={name}
+          onChangeText={setName}
+        />
+        <TextInput
+          placeholder="Amount"
+          keyboardType="numeric"
+          style={styles.input}
+          value={amount}
+          onChangeText={setAmount}
+        />
+        <TextInput
+          placeholder="YYYY-MM-DD"
+          style={styles.input}
+          value={date}
+          onChangeText={setDate}
+        />
+        <View style={styles.switchRow}>
+          <ThemedText>Recurring</ThemedText>
+          <Switch value={recurring} onValueChange={setRecurring} />
+        </View>
+        <Button title="Add" onPress={addIncome} />
+      </View>
+      <FlatList
+        data={incomes}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.item}>
+            <ThemedText style={styles.itemName}>{item.name}</ThemedText>
+            <ThemedText>${item.amount}</ThemedText>
+            <ThemedText>{item.date}</ThemedText>
+            {item.recurring ? <ThemedText>Recurring</ThemedText> : null}
+          </View>
+        )}
+      />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  header: {
+    marginBottom: 8,
+  },
+  total: {
+    marginBottom: 16,
+  },
+  form: {
+    marginBottom: 24,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 8,
+    borderRadius: 4,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  item: {
+    padding: 8,
+    borderBottomWidth: 1,
+    borderColor: '#ccc',
+  },
+  itemName: {
+    fontWeight: 'bold',
+  },
+});

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'dollarsign.circle': 'attach-money',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- add `income.tsx` screen to create and list income events
- show total income for the current month
- hook screen into the tab navigator
- add dollar icon mapping for the new tab

## Testing
- `npm run lint` *(fails: `expo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6858812280108325aacc4cbaac1c8fd7